### PR TITLE
Fixup diffs between versions 1.4.0 and 1.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,25 +13,25 @@ module.exports = function normalize (color, type) {
 	var Ctor = dtype(type)
 	var output = new Ctor(4)
 
-	//same class does not change values
-	if (color instanceof Ctor) {
-		if (Array.isArray(color)) {
-			return color.slice()
-		}
-
-		output.set(color)
-
-		return output
-	}
-
 	var normalize = type !== 'uint8' && type !== 'uint8_clamped'
 
-	//consider uint8 array as 0..255 channel values
-	if (color instanceof Uint8Array || color instanceof Uint8ClampedArray) {
+	// attempt to parse non-array arguments
+	if (!color.length || typeof color === 'string') {
+		color = rgba(color)
+		color[0] /= 255
+		color[1] /= 255
+		color[2] /= 255
+	}
+
+	// 0, 1 are possible contradictory values for Arrays:
+	// [1,1,1] input gives [1,1,1] output instead of [1/255,1/255,1/255], which may be collision if input is meant to be uint.
+	// converting [1,1,1] to [1/255,1/255,1/255] in case of float input gives larger mistake since [1,1,1] float is frequent edge value, whereas [0,1,1], [1,1,1] etc. uint inputs are relatively rare
+	if (isInt(color)) {
 		output[0] = color[0]
 		output[1] = color[1]
 		output[2] = color[2]
 		output[3] = color[3] != null ? color[3] : 255
+
 		if (normalize) {
 			output[0] /= 255
 			output[1] /= 255
@@ -42,19 +42,10 @@ module.exports = function normalize (color, type) {
 		return output
 	}
 
-	//attempt to parse non-array arguments
-	if (!color.length || typeof color === 'string') {
-		color = rgba(color)
-		color[0] /= 255
-		color[1] /= 255
-		color[2] /= 255
-	}
-
-	//consider every other array type as 0..1 float values
 	if (!normalize) {
-		output[0] = clamp(Math.round(color[0] * 255), 0, 255)
-		output[1] = clamp(Math.round(color[1] * 255), 0, 255)
-		output[2] = clamp(Math.round(color[2] * 255), 0, 255)
+		output[0] = clamp(Math.floor(color[0] * 255), 0, 255)
+		output[1] = clamp(Math.floor(color[1] * 255), 0, 255)
+		output[2] = clamp(Math.floor(color[2] * 255), 0, 255)
 		output[3] = color[3] == null ? 255 : clamp(Math.floor(color[3] * 255), 0, 255)
 	} else {
 		output[0] = color[0]
@@ -64,4 +55,17 @@ module.exports = function normalize (color, type) {
 	}
 
 	return output
+}
+
+function isInt(color) {
+	if (color instanceof Uint8Array || color instanceof Uint8ClampedArray) return true
+
+	if (Array.isArray(color) &&
+		(color[0] > 1 || color[0] === 0) &&
+		(color[1] > 1 || color[1] === 0) &&
+		(color[2] > 1 || color[2] === 0) &&
+		(!color[3] || color[3] > 1)
+	) return true
+
+	return false
 }

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 Convert any color argument (string, color, number, object etc.) to an array with channels data of desired output format.
 
+
 ## Usage
 
 [![npm install color-normalize](https://nodei.co/npm/color-normalize.png?mini=true)](https://npmjs.org/package/color-normalize/)
@@ -15,9 +16,17 @@ rgba('rgba(255, 255, 255, .5)', 'float64') // Float64Array<[1, 1, 1, .5]>
 rgba('hsla(109, 50%, 50%, .75)', 'uint8') // Uint8Array<[87, 191, 64, 191]>
 rgba(new Float32Array([0, 0.25, 0, 1]), 'uint8_clamped') // Uint8ClampedArray<[0, 64, 0, 255]>
 rgba(new Uint8Array([0, 72, 0, 255]), 'array') // [0, 0.2823529411764706, 0, 1]
+
+// ambivalent input
+rgba([0,0,0]) // [0,0,0]
+rgba([.5,.5,.5]) // [.5,.5,.5]
+rgba([1,1,1]) // [1,1,1]
+rgba([127,127,127]) // [.5,.5,.5]
+rgba([255,255,255]) // [1,1,1]
 ```
 
-Output format can be any [dtype](https://npmjs.org/package/dtype): `uint8`, `uint8_clamped`, `array`, `float32`, `float64` etc.
+Output format can be any [dtype](https://npmjs.org/package/dtype): `uint8`, `uint8_clamped`, `array`, `float32`, `float64` etc. By default it converts to `array` with `0..1` range values.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,14 +1,38 @@
+'use strict'
+
 const assert = require('assert')
 const rgba = require('./')
 
 assert.deepEqual(rgba('red'), [1, 0, 0, 1])
-
 assert.deepEqual(rgba('rgb(80, 120, 160)', 'uint8'), new Uint8Array([80, 120, 160, 255]))
+assert.deepEqual(rgba('rgb(255, 255, 255, .5)', 'float64'), new Float64Array([1, 1, 1, 1]))
 assert.deepEqual(rgba('rgba(255, 255, 255, .5)', 'float64'), new Float64Array([1, 1, 1, .5]))
-assert.deepEqual(rgba('hsla(109, 50%, 50%, .75)', 'uint8'), new Uint8Array([87, 191, 64, 191]))
-assert.deepEqual(rgba(new Float32Array([0, 0.25, 0, 1]), 'uint8_clamped'), new Uint8ClampedArray([0, 64, 0, 255]))
+assert.deepEqual(rgba('hsla(109, 50%, 50%, .75)', 'uint8'), new Uint8Array([87, 191, 63, 191]))
+assert.deepEqual(rgba(new Float32Array([0, 0.25, 0, 1]), 'uint8_clamped'), new Uint8ClampedArray([0, 63, 0, 255]))
 assert.deepEqual(rgba(new Uint8Array([0, 72, 0, 255]), 'array'), [0, 0.2823529411764706, 0, 1])
 assert.deepEqual(rgba(new Uint8Array([0, 72, 0, 255]), 'uint8'), new Uint8Array([0, 72, 0, 255]))
 
 assert.deepEqual(rgba([0,0,0,1]), [0,0,0,1])
 assert.deepEqual(rgba(0x00ff00), [0,1,0,1])
+
+assert.deepEqual(rgba(new Uint8Array([0, 72, 0]), 'uint8'), new Uint8Array([0, 72, 0, 255]))
+
+assert.deepEqual(rgba([127.5,127.5,127.5,127.5]), [.5,.5,.5,.5])
+assert.deepEqual(rgba([127,127,127,127], 'uint8'), new Uint8Array([127,127,127,127]))
+assert.deepEqual(rgba([.5,.5,.5,.5]), [.5,.5,.5,.5])
+assert.deepEqual(rgba([.5,.5,.5,.5], 'uint8'), new Uint8Array([127,127,127,127]))
+assert.deepEqual(rgba([0,0,0,0]), [0,0,0,0])
+assert.deepEqual(rgba([0,0,0,0], 'uint'), new Uint8Array([0,0,0,0]))
+assert.deepEqual(rgba([0,0,0]), [0,0,0,1])
+assert.deepEqual(rgba([0,0,0], 'uint'), new Uint8Array([0,0,0,255]))
+assert.deepEqual(rgba([0,0,1]), [0,0,1,1])
+assert.deepEqual(rgba([0,0,1], 'uint'), new Uint8Array([0,0,255,255]))
+assert.deepEqual(rgba([1,1,1]), [1,1,1,1])
+assert.deepEqual(rgba([1,1,1], 'uint'), new Uint8Array([255,255,255,255]))
+
+
+assert.deepEqual(rgba([0,0,0]), [0,0,0,1])
+// assert.deepEqual(rgba([.5,.5,.5]), [.5,.5,.5,1])
+assert.deepEqual(rgba([1,1,1]), [1,1,1,1])
+assert.deepEqual(rgba([127.5,127.5,127.5]), [.5,.5,.5,1])
+assert.deepEqual(rgba([255,255,255]), [1,1,1,1])


### PR DESCRIPTION
As @dy pointed out in https://github.com/colorjs/color-normalize/issues/5 the improvements made in versions 1.2.0 and 1.3.0 are not reflected in the repository.
This PR re-applies those changes.
@dy @zeke 
cc: @etpinard